### PR TITLE
開発者情報を訂正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+*.iml
 tool-generate-captures/node_modules/*
 tool-generate-captures/.idea/workspace.xml
 

--- a/docs/basic.md
+++ b/docs/basic.md
@@ -4,7 +4,7 @@
 
 ![CreateJSの導入編](../imgs/title_createjs.jpg)
 
-[CreateJS](http://www.createjs.com)は、HTML5でリッチコンテンツを制作するためのJavaScriptライブラリのスイート（特定用途のソフトウェアを詰め合わせたパッケージ）です。Flashデベロッパーとして著名なGrant Skinner氏が開発を行っており、オープンソースソフトウェアとして個人・商用でも無償で利用できます。
+[CreateJS](http://www.createjs.com)は、HTML5でリッチコンテンツを制作するためのJavaScriptライブラリのスイート（特定用途のソフトウェアを詰め合わせたパッケージ）です。Flashデベロッパーとして著名なGrant Skinner氏が代表を務めるgskinner社が開発を行っており、オープンソースソフトウェアとして個人・商用でも無償で利用できます。
 
 ## CreateJS を構成する4つのJSライブラリ
 


### PR DESCRIPTION
CreateJSの開発がGrant Skinner個人で行われているかのように読めるので、社が開発を行っている（正確にはオープンソースなので有志も入っているが、公式にはbuilt by gskinnerとされている）ことが分かるように訂正した。

ついでに.gitignoreにJetBrains製IDEのモジュール定義ファイル形式も追加した（1つのプルリクに混ぜちゃってすみません）。
